### PR TITLE
Add & Clean POIs classes

### DIFF
--- a/layers/poi/class.sql
+++ b/layers/poi/class.sql
@@ -2,10 +2,11 @@ CREATE OR REPLACE FUNCTION poi_class_rank(class TEXT)
 RETURNS INT AS $$
     SELECT CASE class
         WHEN 'hospital' THEN 20
-        WHEN 'park' THEN 25
-        WHEN 'cemetery' THEN 30
+        WHEN 'fire_station' THEN 30
+        WHEN 'bicycle' THEN 35
         WHEN 'railway' THEN 40
         WHEN 'bus' THEN 50
+        WHEN 'sport' THEN 65
         WHEN 'attraction' THEN 70
         WHEN 'harbor' THEN 75
         WHEN 'college' THEN 80
@@ -24,6 +25,7 @@ RETURNS INT AS $$
         WHEN 'grocery' THEN 500
         WHEN 'fast_food' THEN 600
         WHEN 'clothing_store' THEN 700
+        WHEN 'restaurant' THEN 750
         WHEN 'bar' THEN 800
         ELSE 1000
     END;
@@ -32,11 +34,11 @@ $$ LANGUAGE SQL IMMUTABLE;
 CREATE OR REPLACE FUNCTION poi_class(subclass TEXT, mapping_key TEXT)
 RETURNS TEXT AS $$
     SELECT CASE
-        WHEN subclass IN ('accessories','antiques','art','beauty','bed','boutique','camera','carpet','charity','chemist','chocolate','coffee','computer','confectionery','convenience','copyshop','cosmetics','garden_centre','doityourself','erotic','electronics','fabric','florist','furniture','video_games','video','general','gift','hardware','hearing_aids','hifi','ice_cream','interior_decoration','jewelry','kiosk','lamps','mall','massage','motorcycle','mobile_phone','newsagent','optician','outdoor','perfumery','perfume','pet','photo','second_hand','shoes','sports','stationery','tailor','tattoo','ticket','tobacco','toys','travel_agency','watches','weapons','wholesale') THEN 'shop'
-        WHEN subclass IN ('townhall','public_building','courthouse','community_centre') THEN 'town_hall'
+        WHEN subclass IN ('accessories','antiques','beauty','bed','boutique','camera','carpet','charity','chemist','chocolate','computer','confectionery','convenience','copyshop','cosmetics','doityourself','erotic','electronics','fabric','florist','furniture','video_games','video','general','gift','hardware','hearing_aids','hifi','interior_decoration','jewelry','kiosk','lamps','mall','massage','mobile_phone','newsagent','optician','outdoor','perfumery','perfume','pet','photo','second_hand','shoes','stationery','tailor','tattoo','ticket','tobacco','toys','travel_agency','watches','weapons','wholesale', 'bank', 'bureau_de_change', 'casino', 'cinema') THEN 'shop'
+        WHEN subclass IN ('townhall','public_building','courthouse','community_centre', 'embassy') THEN 'town_hall'
         WHEN subclass IN ('golf','golf_course','miniature_golf') THEN 'golf'
         WHEN subclass IN ('fast_food','food_court') THEN 'fast_food'
-        WHEN subclass IN ('park','bbq') THEN 'park'
+        WHEN subclass IN ('park','bbq', 'garden_centre') THEN 'park'
         WHEN subclass IN ('bus_stop','bus_station') THEN 'bus'
         WHEN (subclass='station' AND mapping_key = 'railway') OR subclass IN ('halt', 'tram_stop', 'subway') THEN 'railway'
         WHEN (subclass='station' AND mapping_key = 'aerialway') THEN 'aerialway'
@@ -46,24 +48,28 @@ RETURNS TEXT AS $$
         WHEN subclass IN ('books','library') THEN 'library'
         WHEN subclass IN ('university','college') THEN 'college'
         WHEN subclass IN ('hotel','motel','bed_and_breakfast','guest_house','hostel','chalet','alpine_hut','camp_site') THEN 'lodging'
-        WHEN subclass IN ('chocolate','confectionery') THEN 'ice_cream'
+        WHEN subclass IN ('chocolate','confectionery', 'ice_cream') THEN 'ice_cream'
         WHEN subclass IN ('post_box','post_office') THEN 'post'
-        WHEN subclass IN ('cafe') THEN 'cafe'
+        WHEN subclass IN ('cafe', 'coffee') THEN 'cafe'
         WHEN subclass IN ('school','kindergarten') THEN 'school'
-        WHEN subclass IN ('alcohol','beverages','wine') THEN 'alcohol_shop'
+        WHEN subclass IN ('alcohol','beverages','wine', 'nightclub') THEN 'alcohol_shop'
         WHEN subclass IN ('bar','nightclub') THEN 'bar'
-        WHEN subclass IN ('marina','dock') THEN 'harbor'
-        WHEN subclass IN ('car','car_repair','taxi') THEN 'car'
-        WHEN subclass IN ('hospital','nursing_home', 'doctors', 'clinic') THEN 'hospital'
+        WHEN subclass IN ('marina','dock', 'boat_rental', 'boat_sharing', 'ferry_terminal') THEN 'harbor'
+        WHEN subclass IN ('car','car_repair','taxi', 'fuel', 'parking', 'car_wash', 'car_rental', 'charging_station', 'parking_space') THEN 'car'
+        WHEN subclass IN ('hospital','nursing_home', 'doctors', 'clinic', 'dentist', 'pharmacy', 'veterinary') THEN 'hospital'
         WHEN subclass IN ('grave_yard','cemetery') THEN 'cemetery'
         WHEN subclass IN ('attraction','viewpoint') THEN 'attraction'
         WHEN subclass IN ('biergarten','pub') THEN 'beer'
         WHEN subclass IN ('music','musical_instrument') THEN 'music'
         WHEN subclass IN ('american_football','stadium','soccer','pitch') THEN 'stadium'
-        WHEN subclass IN ('accessories','antiques','art','artwork','gallery','arts_centre') THEN 'art_gallery'
+        WHEN subclass IN ('antiques','art','artwork','gallery','arts_centre', 'theatre') THEN 'art_gallery'
         WHEN subclass IN ('bag','clothes') THEN 'clothing_store'
         WHEN subclass IN ('swimming_area','swimming') THEN 'swimming'
         WHEN subclass IN ('castle','ruins') THEN 'castle'
+        WHEN subclass IN ('restaurant', 'drinking_water') THEN 'restaurant'
+        WHEN subclass IN ('dive_centre', 'sports', 'dojo') THEN 'sport'
+        WHEN subclass IN ('bicycle', 'bicycle_parking', 'bicycle_rental', 'motorcycle', 'motorcycle_parking') THEN 'bicycle'
+        WHEN subclass IN ('firestation', 'fire_station') THEN 'fire_station'
         ELSE subclass
     END;
 $$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
The rank generation in each cell of the map depends on some POIs classes defined in poi_class_rank() and poi_class() functions.
However these functions don't consider some categories that should require some specific class. 
To solve this we add & clean some of the existing classes.

We added the following cases:
`internet_cafe, bicycle, bicycle_parking, bicycle_rental, boat_rental, boat_sharing, bureau_de_change, car_rental, car_wash, casino, charging_station, cinema, dentists, dive_centre, drinking_water, embassy, ferry_terminal, firestation, fuel, motorcycle_parking, nightclub, parking, restaurant, theatre, toilets, veterinary`