### PR TITLE
Remove duplicates park/cemetery/accessories

### DIFF
--- a/layers/poi/class.sql
+++ b/layers/poi/class.sql
@@ -14,8 +14,6 @@ RETURNS INT AS $$
         WHEN 'zoo' THEN 95
         WHEN 'town_hall' THEN 100
         WHEN 'campsite' THEN 110
-        WHEN 'cemetery' THEN 115
-        WHEN 'park' THEN 120
         WHEN 'library' THEN 130
         WHEN 'police' THEN 135
         WHEN 'post' THEN 140
@@ -60,7 +58,7 @@ RETURNS TEXT AS $$
         WHEN subclass IN ('biergarten','pub') THEN 'beer'
         WHEN subclass IN ('music','musical_instrument') THEN 'music'
         WHEN subclass IN ('american_football','stadium','soccer','pitch') THEN 'stadium'
-        WHEN subclass IN ('accessories','antiques','art','artwork','gallery','arts_centre') THEN 'art_gallery'
+        WHEN subclass IN ('antiques','art','artwork','gallery','arts_centre') THEN 'art_gallery'
         WHEN subclass IN ('bag','clothes') THEN 'clothing_store'
         WHEN subclass IN ('swimming_area','swimming') THEN 'swimming'
         WHEN subclass IN ('castle','ruins') THEN 'castle'


### PR DESCRIPTION
I propose to remove these duplicates:

- "park" appears twice as a class line 5 and line 18.
- "cemetery" appears twice as a class as well line 6 and line 17.
- "accessories" exists already in "shop" class line 33.
