### PR TITLE
Define a global_id on layer 'poi'

### DIFF
--- a/generate_qwant.sh
+++ b/generate_qwant.sh
@@ -15,6 +15,10 @@ for tiles in 'base' 'poi' 'lite'; do
         # no sql and no mapping for the lite tiles
         generate-sql $tileset > $CONFIG_DIR/imposm/generated_$tiles.sql
         generate-imposm3 $tileset > $CONFIG_DIR/imposm/generated_mapping_$tiles.yaml
+
+        # Use "single id space" to store osm_id as integers in a deterministic way
+        # And be able to transform it back to string with osm type (node/way/relation)
+        echo 'use_single_id_space: true' >> $CONFIG_DIR/imposm/generated_mapping_$tiles.yaml
     fi
     TMP_SOURCE=generated_${tiles}_tm2source.yml
     generate-tm2source $tileset  --host="localhost" --port=5432 --database="gis" --user="nice_user" --password="nice_password" > $TMP_SOURCE

--- a/layers/building/building.sql
+++ b/layers/building/building.sql
@@ -68,7 +68,7 @@ CREATE OR REPLACE VIEW osm_all_buildings AS (
                   COALESCE(nullif(as_numeric(levels),-1),nullif(as_numeric(buildinglevels),-1)) as levels,
                   COALESCE(nullif(as_numeric(min_level),-1),nullif(as_numeric(buildingmin_level),-1)) as min_level
          FROM
-         osm_building_polygon WHERE osm_id >= 0
+         osm_building_polygon WHERE osm_id >= -1e17
 );
 
 CREATE OR REPLACE FUNCTION layer_building(bbox geometry, zoom_level int)

--- a/layers/building/mapping.yaml
+++ b/layers/building/mapping.yaml
@@ -386,7 +386,3 @@ tables:
         building: ["no","none","No"]
         building:part: ["no","none","No"]
     type: relation_member
-
-tags:
-  # Note we want in general to load all tags, so we define it there (but it could have been generated in any layers)
-  load_all: true

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -1,3 +1,4 @@
+
 CREATE OR REPLACE FUNCTION global_id_from_imposm(osm_id bigint, osm_type text)
 RETURNS TEXT AS $$
     SELECT CONCAT(
@@ -12,9 +13,10 @@ $$ LANGUAGE SQL IMMUTABLE;
 
 -- etldoc: layer_poi[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_poi | <z12> z12 | <z13> z13 | <z14_> z14+" ] ;
+
 CREATE OR REPLACE FUNCTION layer_poi(bbox geometry, zoom_level integer, pixel_width numeric)
 RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_en text, name_de text, tags hstore, class text, subclass text, agg_stop integer, "rank" int) AS $$
-    SELECT osm_id_hash AS osm_id, global_id
+    SELECT osm_id_hash AS osm_id, global_id,
         geometry, NULLIF(name, '') AS name,
         COALESCE(NULLIF(name_en, ''), name) AS name_en,
         COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -1,11 +1,20 @@
 
-CREATE OR REPLACE FUNCTION global_id_from_imposm(osm_id bigint)
+CREATE OR REPLACE FUNCTION osm_hash_from_imposm(imposm_id bigint)
+RETURNS bigint AS $$
+    SELECT CASE
+        WHEN imposm_id < -1e17 THEN (-imposm_id-1e17) * 10 + 4 -- Relation
+        WHEN imposm_id < 0 THEN  (-imposm_id) * 10 + 1 -- Way
+        ELSE imposm_id * 10 -- Node
+    END::bigint;
+$$ LANGUAGE SQL IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION global_id_from_imposm(imposm_id bigint)
 RETURNS TEXT AS $$
     SELECT CONCAT(
         'osm:',
-        CASE WHEN osm_id < -1e17 THEN CONCAT('relation:', -osm_id-1e17)
-             WHEN osm_id < 0 THEN CONCAT('way:', -osm_id)
-             ELSE CONCAT('node:', osm_id)
+        CASE WHEN imposm_id < -1e17 THEN CONCAT('relation:', -imposm_id-1e17)
+             WHEN imposm_id < 0 THEN CONCAT('way:', -imposm_id)
+             ELSE CONCAT('node:', imposm_id)
         END
     );
 $$ LANGUAGE SQL IMMUTABLE;
@@ -36,7 +45,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
         -- etldoc: osm_poi_point ->  layer_poi:z12
         -- etldoc: osm_poi_point ->  layer_poi:z13
         SELECT *,
-            osm_id*10 AS osm_id_hash,
+            osm_hash_from_imposm(osm_id) AS osm_id_hash,
             global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_point
             WHERE geometry && bbox
@@ -47,7 +56,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
 
         -- etldoc: osm_poi_point ->  layer_poi:z14_
         SELECT *,
-            osm_id*10 AS osm_id_hash,
+            osm_hash_from_imposm(osm_id) AS osm_id_hash,
             global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_point
             WHERE geometry && bbox
@@ -58,9 +67,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
         -- etldoc: osm_poi_polygon ->  layer_poi:z13
         SELECT *,
             NULL::INTEGER AS agg_stop,
-            CASE WHEN osm_id<0 THEN -osm_id*10+4
-                ELSE osm_id*10+1
-            END AS osm_id_hash,
+            osm_hash_from_imposm(osm_id) AS osm_id_hash,
             global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox
@@ -72,9 +79,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
         -- etldoc: osm_poi_polygon ->  layer_poi:z14_
         SELECT *,
             NULL::INTEGER AS agg_stop,
-            CASE WHEN osm_id<0 THEN -osm_id*10+4
-                ELSE osm_id*10+1
-            END AS osm_id_hash,
+            osm_hash_from_imposm(osm_id) AS osm_id_hash,
             global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -1,10 +1,21 @@
+CREATE OR REPLACE FUNCTION global_id_from_imposm(osm_id bigint, osm_type text)
+RETURNS TEXT AS $$
+    SELECT CONCAT(
+        'osm:',
+        CASE WHEN osm_id<0
+            THEN CONCAT('relation:', -osm_id)
+            ELSE CONCAT(osm_type, ':', osm_id)
+        END
+    );
+$$ LANGUAGE SQL IMMUTABLE;
+
 
 -- etldoc: layer_poi[shape=record fillcolor=lightpink, style="rounded,filled",
 -- etldoc:     label="layer_poi | <z12> z12 | <z13> z13 | <z14_> z14+" ] ;
-
 CREATE OR REPLACE FUNCTION layer_poi(bbox geometry, zoom_level integer, pixel_width numeric)
-RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de text, tags hstore, class text, subclass text, agg_stop integer, "rank" int) AS $$
-    SELECT osm_id_hash AS osm_id, geometry, NULLIF(name, '') AS name,
+RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_en text, name_de text, tags hstore, class text, subclass text, agg_stop integer, "rank" int) AS $$
+    SELECT osm_id_hash AS osm_id, global_id
+        geometry, NULLIF(name, '') AS name,
         COALESCE(NULLIF(name_en, ''), name) AS name_en,
         COALESCE(NULLIF(name_de, ''), name, name_en) AS name_de,
         tags,
@@ -23,7 +34,9 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
         -- etldoc: osm_poi_point ->  layer_poi:z12
         -- etldoc: osm_poi_point ->  layer_poi:z13
         SELECT *,
-            osm_id*10 AS osm_id_hash FROM osm_poi_point
+            osm_id*10 AS osm_id_hash,
+            global_id_from_imposm(osm_id, 'node') as global_id
+        FROM osm_poi_point
             WHERE geometry && bbox
                 AND zoom_level BETWEEN 12 AND 13
                 AND ((subclass='station' AND mapping_key = 'railway')
@@ -32,7 +45,9 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
 
         -- etldoc: osm_poi_point ->  layer_poi:z14_
         SELECT *,
-            osm_id*10 AS osm_id_hash FROM osm_poi_point
+            osm_id*10 AS osm_id_hash,
+            global_id_from_imposm(osm_id, 'node') as global_id
+        FROM osm_poi_point
             WHERE geometry && bbox
                 AND zoom_level >= 14
 
@@ -43,7 +58,8 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
             NULL::INTEGER AS agg_stop,
             CASE WHEN osm_id<0 THEN -osm_id*10+4
                 ELSE osm_id*10+1
-            END AS osm_id_hash
+            END AS osm_id_hash,
+            global_id_from_imposm(osm_id, 'way') as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox
                 AND zoom_level BETWEEN 12 AND 13
@@ -56,7 +72,8 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, name_de
             NULL::INTEGER AS agg_stop,
             CASE WHEN osm_id<0 THEN -osm_id*10+4
                 ELSE osm_id*10+1
-            END AS osm_id_hash
+            END AS osm_id_hash,
+            global_id_from_imposm(osm_id, 'way') as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox
                 AND zoom_level >= 14

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -1,11 +1,11 @@
 
-CREATE OR REPLACE FUNCTION global_id_from_imposm(osm_id bigint, osm_type text)
+CREATE OR REPLACE FUNCTION global_id_from_imposm(osm_id bigint)
 RETURNS TEXT AS $$
     SELECT CONCAT(
         'osm:',
-        CASE WHEN osm_id<0
-            THEN CONCAT('relation:', -osm_id)
-            ELSE CONCAT(osm_type, ':', osm_id)
+        CASE WHEN osm_id < -1e17 THEN CONCAT('relation:', -osm_id-1e17)
+             WHEN osm_id < 0 THEN CONCAT('way:', -osm_id)
+             ELSE CONCAT('node:', osm_id)
         END
     );
 $$ LANGUAGE SQL IMMUTABLE;
@@ -37,7 +37,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
         -- etldoc: osm_poi_point ->  layer_poi:z13
         SELECT *,
             osm_id*10 AS osm_id_hash,
-            global_id_from_imposm(osm_id, 'node') as global_id
+            global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_point
             WHERE geometry && bbox
                 AND zoom_level BETWEEN 12 AND 13
@@ -48,7 +48,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
         -- etldoc: osm_poi_point ->  layer_poi:z14_
         SELECT *,
             osm_id*10 AS osm_id_hash,
-            global_id_from_imposm(osm_id, 'node') as global_id
+            global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_point
             WHERE geometry && bbox
                 AND zoom_level >= 14
@@ -61,7 +61,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
             CASE WHEN osm_id<0 THEN -osm_id*10+4
                 ELSE osm_id*10+1
             END AS osm_id_hash,
-            global_id_from_imposm(osm_id, 'way') as global_id
+            global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox
                 AND zoom_level BETWEEN 12 AND 13
@@ -75,7 +75,7 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
             CASE WHEN osm_id<0 THEN -osm_id*10+4
                 ELSE osm_id*10+1
             END AS osm_id_hash,
-            global_id_from_imposm(osm_id, 'way') as global_id
+            global_id_from_imposm(osm_id) as global_id
         FROM osm_poi_polygon
             WHERE geometry && bbox
                 AND zoom_level >= 14

--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -399,3 +399,6 @@ tables:
       sport: *poi_mapping_sport
       tourism: *poi_mapping_tourism
       waterway: *poi_mapping_waterway
+
+tags:
+  load_all: true

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -45,7 +45,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, '{{}}' as tags FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, tags::json::text as tags FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -45,7 +45,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, '{{}}' as tags FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -45,7 +45,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, tags::json::text as "tags" FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -45,7 +45,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, hstore_to_json(tags)#>>'{}' as "tags" FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, tags::json::text as "tags" FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -45,7 +45,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, hstore_to_json(tags)#>>'{}' as "tags" FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, rank, hstore_to_json(tags)#>>'{}' as "tags" FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql

--- a/openmaptiles_base.yaml
+++ b/openmaptiles_base.yaml
@@ -10,6 +10,7 @@ tileset:
     - layers/aeroway/aeroway.yaml
     - layers/transportation/transportation.yaml
     - layers/building/building.yaml
+    - layers/water_name/water_name.yaml
     - layers/transportation_name/transportation_name.yaml
     - layers/place/place.yaml
     - layers/housenumber/housenumber.yaml


### PR DESCRIPTION
* A new property `global_id` is defined on layer `poi` based on imposm ids (table-dependent, and negative for relations)
* POI tags are loaded to postgres but are no longer included in tiles (this should close #4)

---
TODO:

* Define a similar global_id on `aerodrome_label` layer ?