### PR TITLE
Handle invalid geometry on poi polygon update

### DIFF
--- a/layers/poi/update_poi_polygon.sql
+++ b/layers/poi/update_poi_polygon.sql
@@ -9,7 +9,7 @@ BEGIN
   SET geometry =
            CASE WHEN ST_NPoints(ST_ConvexHull(geometry))=ST_NPoints(geometry)
            THEN ST_Centroid(geometry)
-           ELSE ST_PointOnSurface(geometry)
+           ELSE ST_PointOnSurface(ST_MakeValid(geometry))
     END
   WHERE ST_GeometryType(geometry) <> 'ST_Point';
 


### PR DESCRIPTION
Here is a simple fix to validate geometry before calling `ST_PointOnSurface`, that may fail when  invalid geometries have been imported into the database.

See https://github.com/openmaptiles/openmaptiles/issues/487 for more details.

I could not measure any significant difference about performance when applying updates on lle-de-France.


