### PR TITLE
Fix update_route_member for compatibility with imposm 0.8

### DIFF
--- a/layers/transportation/mapping.yaml
+++ b/layers/transportation/mapping.yaml
@@ -350,6 +350,8 @@ tables:
   route_member:
     type: relation_member
     columns:
+    - name: osm_id
+      type: id
     - name: member
       type: member_id
     - name: role

--- a/layers/transportation_name/update_route_member.sql
+++ b/layers/transportation_name/update_route_member.sql
@@ -8,14 +8,14 @@ BEGIN
   select st_buffer(geometry, 10000) into gbr_geom from ne_10m_admin_0_countries where iso_a2 = 'GB';
   delete from osm_route_member where network IN('omt-gb-motorway', 'omt-gb-trunk');
 
-  insert into osm_route_member (member, ref, network)
+  insert into osm_route_member (osm_id, member, ref, network)
     (
-      SELECT hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-motorway'
+      SELECT 0, hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-motorway'
       from osm_highway_linestring hw
       where length(hw.ref)>0 and ST_Intersects(hw.geometry, gbr_geom)
         and hw.highway IN ('motorway')
     ) UNION (
-      SELECT hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-trunk'
+      SELECT 0, hw.osm_id, substring(hw.ref from E'^[AM][0-9AM()]+'), 'omt-gb-trunk'
       from osm_highway_linestring hw
       where length(hw.ref)>0 and ST_Intersects(hw.geometry, gbr_geom)
         and hw.highway IN ('trunk')


### PR DESCRIPTION
#21 included a change that removed `osm_id` column from `osm_route_member` table.

This is actually not an acceptable fix for compatibility with imposm 0.8, as imposm relies on this column to apply osm updates.

This PR reverts this change and proposes a more robust fix, that fills extra rows with `osm_id = 0` to keep compatibility with imposm 0.8 (requiring non-null osm_id values).