### PR TITLE
Rank with pageviews

### DIFF
--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -7,10 +7,6 @@ CREATE OR REPLACE FUNCTION poi_display_weight(
     tags hstore
 )
 RETURNS REAL AS $$
-    DECLARE
-        max_views CONSTANT REAL := 1e6;
-        min_views CONSTANT REAL := 50.;
-        views_count real;
     BEGIN
         RETURN CASE
             WHEN name <> '' THEN


### PR DESCRIPTION
The rank of a POI is computed through a weight function now primarily based on page views of its corresponding Wikipedia page, if any, otherwise it will use a similar ranking to the previous method.