### PR TITLE
Optimize layer_poi function called by Fafnir

### DIFF
--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -113,6 +113,5 @@ RETURNS TABLE(osm_id bigint, global_id text, geometry geometry, name text, name_
                 AND zoom_level >= 14
                 AND (name <> '' OR (subclass <> 'garden' AND subclass <> 'park'))
         ) as poi_union
-    ORDER BY "rank"
     ;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -63,7 +63,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, layer, level, indoor, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, layer, level, indoor, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!) ORDER BY rank) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql


### PR DESCRIPTION
#20 implemented the possibility to use `layer_poi` to fetch all POIs from Fafnir.  
(see also https://github.com/QwantResearch/fafnir/pull/32)

However the layer_poi used `ORDER BY "rank"`, where the rank value is quite expensive to compute and is not used by Fafnir.

This PR suggests to move this clause to the tile query, to be computed on tile generation only.