### PR TITLE
transportation_name: fix join of big US roads

### DIFF
--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -37,7 +37,10 @@ CREATE MATERIALIZED VIEW osm_transportation_name_network AS (
                                    ORDER BY rm.network_type) AS "rank",
       hl.z_order
   FROM osm_highway_linestring hl
-  -- hl.osm_id is the id of a way, its sign has to be changed to join
+  -- NOTE: As Qwant uses `use_single_id_space` parameter in imposm, `osm_id`
+  --       columns are modified, but not the column `member`. For a way, the
+  --       transformation only multiplies the id by -1, as defined here:
+  --       https://github.com/omniscale/imposm3/blob/0ca82bbe/writer/ways.go#L60
   left join osm_route_member rm on (rm.member = -hl.osm_id)
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_transportation_name_network USING gist(geometry);

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -37,7 +37,8 @@ CREATE MATERIALIZED VIEW osm_transportation_name_network AS (
                                    ORDER BY rm.network_type) AS "rank",
       hl.z_order
   FROM osm_highway_linestring hl
-  left join osm_route_member rm on (rm.member = hl.osm_id)
+  -- hl.osm_id is the id of a way, its sign has to be changed to join
+  left join osm_route_member rm on (rm.member = -hl.osm_id)
 );
 CREATE INDEX IF NOT EXISTS osm_transportation_name_network_geometry_idx ON osm_transportation_name_network USING gist(geometry);
 


### PR DESCRIPTION
Fix join over big US roads, this will allows to retrieve the `network` attribute in order to correctly display road shields.

![Capture d’écran_2019-12-03_18-34-49](https://user-images.githubusercontent.com/1173464/70074851-dbfd3300-15fb-11ea-98a1-3dea97703caf.png)
