### PR TITLE
Load all tags for POIs dataset

### DIFF
--- a/layers/poi/mapping.yaml
+++ b/layers/poi/mapping.yaml
@@ -388,3 +388,6 @@ tables:
     type: polygon
     fields: *poi_fields
     mapping: *poi_mapping
+
+tags:
+  load_all: true


### PR DESCRIPTION
Sets an option that had been removed in #30  
This options is not set in the original repository but is useful for Qwant Maps to store all OSM tags in the database (and enable these tags to be read by Fafnir)