### PR TITLE
reorder landcover by area to fix overlaps

### DIFF
--- a/layers/landcover/landcover.sql
+++ b/layers/landcover/landcover.sql
@@ -26,63 +26,88 @@ $$ LANGUAGE SQL IMMUTABLE;
 
 -- etldoc: ne_110m_glaciated_areas ->  landcover_z0
 CREATE OR REPLACE VIEW landcover_z0 AS (
-    SELECT NULL::bigint AS osm_id, geometry, 'glacier'::text AS subclass FROM ne_110m_glaciated_areas
+    SELECT
+        NULL::bigint AS osm_id,
+        geometry,
+        'glacier'::text AS subclass,
+        ST_Area(geometry) AS area
+    FROM ne_110m_glaciated_areas
 );
 
 CREATE OR REPLACE VIEW landcover_z2 AS (
     -- etldoc: ne_50m_glaciated_areas ->  landcover_z2
-    SELECT NULL::bigint AS osm_id, geometry, 'glacier'::text AS subclass FROM ne_50m_glaciated_areas
+    SELECT
+        NULL::bigint AS osm_id,
+        geometry,
+        'glacier'::text AS subclass,
+        ST_Area(geometry) AS area
+    FROM ne_50m_glaciated_areas
     UNION ALL
     -- etldoc: ne_50m_antarctic_ice_shelves_polys ->  landcover_z2
-    SELECT NULL::bigint AS osm_id, geometry, 'ice_shelf'::text AS subclass FROM ne_50m_antarctic_ice_shelves_polys
+    SELECT
+        NULL::bigint AS osm_id,
+        geometry,
+        'ice_shelf'::text AS subclass,
+        ST_Area(geometry) AS area
+    FROM ne_50m_antarctic_ice_shelves_polys
 );
 
 CREATE OR REPLACE VIEW landcover_z5 AS (
     -- etldoc: ne_10m_glaciated_areas ->  landcover_z5
-    SELECT NULL::bigint AS osm_id, geometry, 'glacier'::text AS subclass FROM ne_10m_glaciated_areas
+    SELECT
+        NULL::bigint AS osm_id,
+        geometry,
+        'glacier'::text AS subclass,
+        ST_Area(geometry) AS area
+    FROM ne_10m_glaciated_areas
     UNION ALL
     -- etldoc: ne_10m_antarctic_ice_shelves_polys ->  landcover_z5
-    SELECT NULL::bigint AS osm_id, geometry, 'ice_shelf'::text AS subclass FROM ne_10m_antarctic_ice_shelves_polys
+    SELECT
+        NULL::bigint AS osm_id,
+        geometry,
+        'ice_shelf'::text AS subclass,
+        ST_Area(geometry) AS area
+    FROM ne_10m_antarctic_ice_shelves_polys
 );
 
 CREATE OR REPLACE VIEW landcover_z7 AS (
     -- etldoc: osm_landcover_polygon_gen7 ->  landcover_z7
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen7
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen7
 );
 
 CREATE OR REPLACE VIEW landcover_z8 AS (
     -- etldoc: osm_landcover_polygon_gen6 ->  landcover_z8
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen6
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen6
 );
 
 CREATE OR REPLACE VIEW landcover_z9 AS (
     -- etldoc: osm_landcover_polygon_gen5 ->  landcover_z9
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen5
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen5
 );
 
 CREATE OR REPLACE VIEW landcover_z10 AS (
     -- etldoc: osm_landcover_polygon_gen4 ->  landcover_z10
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen4
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen4
 );
 
 CREATE OR REPLACE VIEW landcover_z11 AS (
     -- etldoc: osm_landcover_polygon_gen3 ->  landcover_z11
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen3
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen3
 );
 
 CREATE OR REPLACE VIEW landcover_z12 AS (
     -- etldoc: osm_landcover_polygon_gen2 ->  landcover_z12
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen2
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen2
 );
 
 CREATE OR REPLACE VIEW landcover_z13 AS (
     -- etldoc: osm_landcover_polygon_gen1 ->  landcover_z13
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon_gen1
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon_gen1
 );
 
 CREATE OR REPLACE VIEW landcover_z14 AS (
     -- etldoc: osm_landcover_polygon ->  landcover_z14
-    SELECT osm_id, geometry, subclass FROM osm_landcover_polygon
+    SELECT osm_id, geometry, subclass, area FROM osm_landcover_polygon
 );
 
 -- etldoc: layer_landcover[shape=record fillcolor=lightpink, style="rounded, filled", label="layer_landcover | <z0_1> z0-z1 | <z2_4> z2-z4 | <z5_6> z5-z6 |<z7> z7 |<z8> z8 |<z9> z9 |<z10> z10 |<z11> z11 |<z12> z12|<z13> z13|<z14_> z14+" ] ;
@@ -137,5 +162,5 @@ RETURNS TABLE(osm_id bigint, geometry geometry, class text, subclass text) AS $$
         SELECT *
         FROM landcover_z14 WHERE zoom_level >= 14 AND geometry && bbox
     ) AS zoom_levels
-    ORDER BY ST_Area(geometry) DESC;
+    ORDER BY area DESC;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/layers/landcover/landcover.sql
+++ b/layers/landcover/landcover.sql
@@ -136,5 +136,6 @@ RETURNS TABLE(osm_id bigint, geometry geometry, class text, subclass text) AS $$
         -- etldoc:  landcover_z14 -> layer_landcover:z14_
         SELECT *
         FROM landcover_z14 WHERE zoom_level >= 14 AND geometry && bbox
-    ) AS zoom_levels;
+    ) AS zoom_levels
+    ORDER BY ST_Area(geometry) DESC;
 $$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
Here is some examples of local tile generation compared to current production, the previously hidden surfaces are quite easy to pickup as their surrounding is usually still visible:

![test](https://user-images.githubusercontent.com/1173464/87140000-140ad980-c2a1-11ea-9ebf-bbdc3aab97f7.gif)
![test2](https://user-images.githubusercontent.com/1173464/87140003-14a37000-c2a1-11ea-9403-6a2993465ed7.gif)
![test3](https://user-images.githubusercontent.com/1173464/87140004-153c0680-c2a1-11ea-97d3-46a796f04455.gif)