### PR TITLE
Use tag 'recycling_type' as subclass for amenity=recycling

### DIFF
--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -90,6 +90,8 @@ AS $$
                 THEN NULLIF(religion, '')
             WHEN subclass IN ('pitch', 'sports_centre')
                 THEN NULLIF(sport, '')
+            WHEN subclass = 'recycling'
+                THEN COALESCE(tags->'recycling_type', 'recycling')
             ELSE subclass
         END AS subclass,
         agg_stop,


### PR DESCRIPTION
POIs with amenity=recycling are currently imported with class "recycling" and subclass "recycling".  
This PR suggests to use the [`recycling_type`](https://wiki.openstreetmap.org/wiki/Key:recycling_type) tag as the subclass when it's present.