### PR TITLE
Use zres() instead of discouraged !pixel_width! in mapnik SQL queries

### DIFF
--- a/layers/aerodrome_label/aerodrome_label.yaml
+++ b/layers/aerodrome_label/aerodrome_label.yaml
@@ -30,7 +30,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label (!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, iata, icao, ele, ele_ft FROM layer_aerodrome_label (!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric)) AS t
 schema:
   - ./update.sql
   - ./layer.sql

--- a/layers/mountain_peak/mountain_peak.yaml
+++ b/layers/mountain_peak/mountain_peak.yaml
@@ -22,7 +22,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, ele, ele_ft, rank FROM layer_mountain_peak(!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric)) AS t
 schema:
   - ./update_peak_point.sql
   - ./layer.sql

--- a/layers/park/park.yaml
+++ b/layers/park/park.yaml
@@ -16,7 +16,7 @@ layer:
     rank: Rank of the park within one tile, starting at 1 that is the most important park (point features only).
   datasource:
     geometry_field: geometry
-    query: (SELECT geometry, class, name, name_en, name_de, {name_languages}, rank FROM layer_park(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT geometry, class, name, name_en, name_de, {name_languages}, rank FROM layer_park(!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric)) AS t
 schema:
   - ./update_park_polygon.sql
   - ./layer.sql

--- a/layers/place/place.yaml
+++ b/layers/place/place.yaml
@@ -60,7 +60,7 @@ layer:
     geometry_field: geometry
     key_field: osm_id
     key_field_as_attribute: no
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, rank, capital, iso_a2 FROM layer_place(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, rank, capital, iso_a2 FROM layer_place(!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric)) AS t
 schema:
   - ./types.sql
   - ./capital.sql

--- a/layers/place/place_lite.yaml
+++ b/layers/place/place_lite.yaml
@@ -61,7 +61,7 @@ layer:
     geometry_field: geometry
     key_field: osm_id
     key_field_as_attribute: no
-    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, rank, capital, iso_a2 FROM layer_place_lite(!bbox!, z(!scale_denominator!), !pixel_width!)) AS t
+    query: (SELECT osm_id, geometry, name, name_en, name_de, {name_languages}, class, rank, capital, iso_a2 FROM layer_place_lite(!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric)) AS t
 schema: []
 datasources:
   - type: imposm3

--- a/layers/poi/poi.yaml
+++ b/layers/poi/poi.yaml
@@ -64,7 +64,7 @@ layer:
     key_field: osm_id
     key_field_as_attribute: no
     srid: 900913
-    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, layer, level, indoor, rank FROM layer_poi(!bbox!, z(!scale_denominator!), !pixel_width!) ORDER BY rank) AS t
+    query: (SELECT osm_id, geometry, global_id, name, name_en, name_de, {name_languages}, class, subclass, agg_stop, layer, level, indoor, rank FROM layer_poi(!bbox!, z(!scale_denominator!), zres(z(!scale_denominator!))::numeric) ORDER BY rank) AS t
 schema:
   - ./public_transport_stop_type.sql
   - ./update_poi_polygon.sql


### PR DESCRIPTION
## Problem

During the migration of Kartotherian to Node 14, a breaking change has been observed in node-mapnik 4.5 (depending on `mapnik-vector-tile` 3.x). The `!pixel_width!` token used as a placeholder for Mapnik has now a different implementation.

In a nutshell, the pixel width was previously calculated in Mapnik based on the default tile size used by most renderers (256x256), now it's based on the maximum resolution of the vector tile used to simplify geometries (which is 4096px by default to allow overzoom).

It seems that using `!pixel_width!` for vector tile queries is actually a source of confusion, and should be discouraged.
See https://github.com/mapbox/mapnik-vector-tile/pull/290 and also [this comment](https://github.com/mapbox/mapnik-vector-tile/issues/289#issuecomment-411448105) for more details.

## Solution

This PR suggests to use `ZRES()` function defined in "postgis-vt-util" to compute this pseudo-pixel width. 
The function implementation explicitly assumes 256x256 pixels tiles:
https://github.com/openmaptiles/postgis-vt-util/blob/master/src/ZRes.sql

This change is backward compatible and should be more future-proof.

