### PR TITLE
update_city_point: replace ne.gn_ascii join with ne.name_en

### DIFF
--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -23,10 +23,10 @@ BEGIN
           ne.name ILIKE osm.name_en OR
           ne.namealt ILIKE osm.name OR
           ne.namealt ILIKE osm.name_en OR
+          ne.name_en ILIKE osm.name OR
+          ne.name_en ILIKE osm.name_en OR
           ne.meganame ILIKE osm.name OR
           ne.meganame ILIKE osm.name_en OR
-          ne.gn_ascii ILIKE osm.name OR
-          ne.gn_ascii ILIKE osm.name_en OR
           ne.nameascii ILIKE osm.name OR
           ne.nameascii ILIKE osm.name_en OR
           ne.name = unaccent(osm.name)


### PR DESCRIPTION
Here "gn" appears to refer to GeoNames.org as a source. The fields field
`gn_ascii` was deprecated and finally removed in 2021:
https://github.com/nvkelso/natural-earth-vector/issues/477

The deprecation issue recommends to replace the removed field with the
use of `name` (already used) and `name_alts` (which I assume refers to
local variants `name_fr`, `name_en`, ...), so I've included a check on
the English column.

(Note that is probably a temporary fix until we upgrade our openmaptile fork to a more recent version)